### PR TITLE
Flush output in pcap2json tool

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -92,19 +92,20 @@ func TestDEEP(t *testing.T) {
 	}
 
 	if result.Symbol != "SPY" {
-		t.Fatal("Expected symbol = %v, got %v", "SPY", result.Symbol)
+		t.Fatalf("Expected symbol = %v, got %v", "SPY", result.Symbol)
 	}
 }
 
 func TestBook(t *testing.T) {
 	c := setupTestClient()
-	symbols := []string{"SPY", "AAPL"}
+	symbols := []string{"SPY"}
 	result, err := c.GetBook(symbols)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if len(result) != len(symbols) {
+		t.Log(result)
 		t.Fatalf("Received %v results, expected %v", len(result), len(symbols))
 	}
 }

--- a/pcap2json/main.go
+++ b/pcap2json/main.go
@@ -23,6 +23,7 @@ func main() {
 
 	scanner := iex.NewPcapScanner(packetSource)
 	output := bufio.NewWriter(os.Stdout)
+	defer output.Flush()
 	enc := json.NewEncoder(output)
 
 	for {


### PR DESCRIPTION
Fixes second issue in #8, in which output is truncated because it was not flushed before exiting