### PR TITLE
Fix pcap2json output if there are unsupported message type, add OfficialPriceMessage

### DIFF
--- a/iextp/deep/deep.go
+++ b/iextp/deep/deep.go
@@ -24,6 +24,7 @@ const (
 	ShortSalePriceTestStatus = tops.ShortSalePriceTestStatus
 	AuctionInformation       = tops.AuctionInformation
 	TradeReport              = tops.TradeReport
+	OfficialPrice            = tops.OfficialPrice
 	TradeBreak               = tops.TradeBreak
 
 	SecurityEvent            = 0x45
@@ -63,6 +64,8 @@ func Unmarshal(buf []byte) (iextp.Message, error) {
 		msg = &PriceLevelUpdateMessage{}
 	case TradeReport:
 		msg = &TradeReportMessage{}
+	case OfficialPrice:
+		msg = &OfficialPriceMessage{}
 	case TradeBreak:
 		msg = &TradeBreakMessage{}
 	case AuctionInformation:
@@ -81,6 +84,7 @@ type TradingStatusMessage = tops.TradingStatusMessage
 type OperationalHaltStatusMessage = tops.OperationalHaltStatusMessage
 type ShortSalePriceTestStatusMessage = tops.ShortSalePriceTestStatusMessage
 type TradeReportMessage = tops.TradeReportMessage
+type OfficialPriceMessage = tops.OfficialPriceMessage
 type TradeBreakMessage = tops.TradeBreakMessage
 type AuctionInformationMessage = tops.AuctionInformationMessage
 

--- a/iextp/deep/deep_test.go
+++ b/iextp/deep/deep_test.go
@@ -20,7 +20,7 @@ func TestUnmarshal_UnknownMessageType(t *testing.T) {
 		t.Fatal("expected to decode UnsupportedMessage")
 	}
 
-	if !reflect.DeepEqual([]byte(*unkMsg), data) {
+	if !reflect.DeepEqual(unkMsg.Message, data) {
 		t.Fatal("message data not equal to input")
 	}
 }

--- a/iextp/iextp.go
+++ b/iextp/iextp.go
@@ -95,10 +95,14 @@ type Message interface {
 
 // UnsupportedMessage may be returned by a protocol for any
 // message types it does not know how to decode.
-type UnsupportedMessage []byte
+type UnsupportedMessage struct {
+	MessageType uint8
+	Message     []byte
+}
 
 func (m *UnsupportedMessage) Unmarshal(buf []byte) error {
-	*m = buf
+	m.MessageType = uint8(buf[0])
+	m.Message = buf
 	return nil
 }
 

--- a/iextp/tops/tops_test.go
+++ b/iextp/tops/tops_test.go
@@ -20,7 +20,7 @@ func TestUnmarshal_UnknownMessageType(t *testing.T) {
 		t.Fatal("expected to decode UnsupportedMessage")
 	}
 
-	if !reflect.DeepEqual([]byte(*unkMsg), data) {
+	if !reflect.DeepEqual(unkMsg.Message, data) {
 		t.Fatal("message data not equal to input")
 	}
 }
@@ -285,6 +285,34 @@ func TestTradeReportMessage(t *testing.T) {
 
 	if !trMsg.IsVolumeEligible() {
 		t.Error("message is volume eligible")
+	}
+}
+
+func TestOfficialPriceMessage(t *testing.T) {
+	data := []byte{
+		0x58,                                           // X = Official Price
+		0x51,                                           // Q = IEX Official Opening Price
+		0x00, 0xf0, 0x30, 0x2a, 0x5b, 0x25, 0xb6, 0x14, // 2017-04-17 09:30:00.000000000
+		0x5a, 0x49, 0x45, 0x58, 0x54, 0x20, 0x20, 0x20, // ZIEXT
+		0x24, 0x1d, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, // $99.05
+	}
+
+	msg, err := Unmarshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opMsg := *msg.(*OfficialPriceMessage)
+	expected := OfficialPriceMessage{
+		MessageType:   OfficialPrice,
+		PriceType:     OpeningPrice,
+		Timestamp:     time.Date(2017, time.April, 17, 9, 30, 0, 0, time.UTC),
+		Symbol:        "ZIEXT",
+		OfficialPrice: 99.05,
+	}
+
+	if opMsg != expected {
+		t.Fatalf("parsed: %v, expected: %v", msg, expected)
 	}
 }
 

--- a/pcap2json/main.go
+++ b/pcap2json/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/timpalpant/go-iex"
+	"github.com/timpalpant/go-iex/iextp"
 )
 
 func main() {
@@ -33,6 +34,10 @@ func main() {
 			}
 
 			log.Fatal(err)
+		}
+
+		if msg, ok := msg.(*iextp.UnsupportedMessage); ok {
+			log.Printf("WARNING: Unsupported message type %v", byte(msg.MessageType))
 		}
 
 		enc.Encode(msg)


### PR DESCRIPTION
* Changes the format of the UnsupportedMessage type to be JSON-compatible
* Log warning from pcap2json if there are unsupported message types
* Adds support for OfficialPriceMessage (X - 0x58)