### PR TITLE
Update some docs for descriptiveness and typos

### DIFF
--- a/client.go
+++ b/client.go
@@ -203,7 +203,10 @@ type tradingStatusRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// GetOperationalHaltStatus The Exchange may suspend trading of one or more securities on IEX
+// GetOperationalHaltStatus gets all of the instances where the
+// security were halted
+//
+// The Exchange may suspend trading of one or more securities on IEX
 // for operational reasons and indicates such operational halt using
 // the Operational halt status message.
 //
@@ -308,7 +311,7 @@ func (c *Client) GetSymbols() ([]*Symbol, error) {
 	return result, err
 }
 
-// GetIntradayStats gets intra day volume and priceing data
+// GetIntradayStats gets intra day volume and pricing data
 func (c *Client) GetIntradayStats() (*IntradayStats, error) {
 	var result *IntradayStats
 	err := c.getJSON("/stats/intraday", nil, &result)

--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 
 const baseEndpoint = "https://api.iextrading.com/1.0"
 
+// HTTPClient an interface to describe simple requests to a url
 type HTTPClient interface {
 	Get(url string) (resp *http.Response, err error)
 }
@@ -21,11 +22,12 @@ type Client struct {
 	client HTTPClient
 }
 
+// NewClient create a new client
 func NewClient(client HTTPClient) *Client {
 	return &Client{client}
 }
 
-// TOPS provides IEX’s aggregated best quoted bid and offer
+// GetTOPS provides IEX’s aggregated best quoted bid and offer
 // position in near real time for all securities on IEX’s
 // displayed limit order book. TOPS is ideal for developers
 // needing both quote and trade data.
@@ -43,7 +45,7 @@ type topsRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// Last provides trade data for executions on IEX.
+// GetLast provides trade data for executions on IEX.
 // It is a near real time, intraday API that provides IEX last sale price,
 // size and time. Last is ideal for developers that need a lightweight
 // stock quote.
@@ -61,7 +63,7 @@ type lastRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// HIST will provide the output of IEX data products for download on
+// GetHIST will provide the output of IEX data products for download on
 // a T+1 basis. Data will remain available for the trailing twelve months.
 //
 // Only data for the given day will be returned.
@@ -88,7 +90,7 @@ func (c *Client) GetAllAvailableHIST() (map[string][]*HIST, error) {
 	return result, err
 }
 
-// DEEP is used to receive real-time depth of book quotations direct from IEX.
+// GetDEEP is used to receive real-time depth of book quotations direct from IEX.
 // The depth of book quotations received via DEEP provide an aggregated size
 // of resting displayed orders at a price and side, and do not indicate the
 // size or number of individual orders at any price level. Non-displayed
@@ -109,7 +111,7 @@ type deepRequest struct {
 	Symbols string `url:"symbols"`
 }
 
-// Book shows IEX’s bids and asks for given symbols.
+// GetBook shows IEX’s bids and asks for given symbols.
 //
 // A maximumum of 10 symbols may be requested.
 func (c *Client) GetBook(symbols []string) (map[string]*Book, error) {
@@ -123,7 +125,7 @@ type bookRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// Trade report messages are sent when an order on the IEX Order Book is
+// GetTrades report messages are sent when an order on the IEX Order Book is
 // executed in whole or in part. DEEP sends a Trade report message for
 // every individual fill.
 //
@@ -141,7 +143,7 @@ type tradesRequest struct {
 	Last    int      `url:"last,omitempty"`
 }
 
-// The System event message is used to indicate events that apply to
+// GetSystemEvents gets the system event message which is used to indicate events that apply to
 // the market or the data feed.
 //
 // There will be a single message disseminated per channel for each
@@ -159,8 +161,9 @@ type systemEventRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// The Trading status message is used to indicate the current trading status
-// of a security. For IEX-listed securities, IEX acts as the primary market
+// GetTradingStatus gets the trading status message which, is used to
+// indicate the current trading status of a security.
+// For IEX-listed securities, IEX acts as the primary market
 // and has the authority to institute a trading halt or trading pause in a
 // security due to news dissemination or regulatory reasons. For
 // non-IEX-listed securities, IEX abides by any regulatory trading halts
@@ -200,7 +203,7 @@ type tradingStatusRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// The Exchange may suspend trading of one or more securities on IEX
+// GetOperationalHaltStatus The Exchange may suspend trading of one or more securities on IEX
 // for operational reasons and indicates such operational halt using
 // the Operational halt status message.
 //
@@ -229,7 +232,7 @@ type opHaltStatusRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// In association with Rule 201 of Regulation SHO, the Short Sale
+// GetShortSaleRestriction In association with Rule 201 of Regulation SHO, the Short Sale
 // Price Test Message is used to indicate when a short sale price
 // test restriction is in effect for a security.
 //
@@ -253,7 +256,7 @@ type ssrStatusRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// The Security event message is used to indicate events that
+// GetSecurityEvents The Security event message is used to indicate events that
 // apply to a security. A Security event message will be sent
 // whenever such event occurs.
 //
@@ -269,7 +272,7 @@ type securityEventRequest struct {
 	Symbols []string `url:"symbols,comma,omitempty"`
 }
 
-// Trade break messages are sent when an execution on IEX is broken
+// GetTradeBreaks Trade break messages are sent when an execution on IEX is broken
 // on that same trading day. Trade breaks are rare and only affect
 // applications that rely upon IEX execution based data.
 //
@@ -287,7 +290,7 @@ type tradeBreaksRequest struct {
 	Last    int      `url:"last,omitempty"`
 }
 
-// This endpoint returns near real time traded volume on the markets.
+// GetMarkets This endpoint returns near real time traded volume on the markets.
 // Market data is captured by the IEX system from approximately
 // 7:45 a.m. to 5:15 p.m. ET.
 func (c *Client) GetMarkets() ([]*Market, error) {
@@ -305,13 +308,14 @@ func (c *Client) GetSymbols() ([]*Symbol, error) {
 	return result, err
 }
 
+// GetIntradayStats gets intra day volume and priceing data
 func (c *Client) GetIntradayStats() (*IntradayStats, error) {
 	var result *IntradayStats
 	err := c.getJSON("/stats/intraday", nil, &result)
 	return result, err
 }
 
-// This call will return a minimum of the last five trading days up
+// GetRecentStats This call will return a minimum of the last five trading days up
 // to all trading days of the current month.
 func (c *Client) GetRecentStats() ([]*Stats, error) {
 	var result []*Stats
@@ -319,7 +323,7 @@ func (c *Client) GetRecentStats() ([]*Stats, error) {
 	return result, err
 }
 
-// Historical data is only available for prior months,
+// GetHistoricalSummary Historical data is only available for prior months,
 // starting with January 2014.
 // If date IsZero(), returns the prior month's data.
 func (c *Client) GetHistoricalSummary(date time.Time) (*HistoricalSummary, error) {
@@ -337,7 +341,7 @@ type historicalSummaryRequest struct {
 	Date string `url:"date,omitempty"`
 }
 
-// This call will return daily stats for a given month or day.
+// GetHistoricalDaily This call will return daily stats for a given month or day.
 // Historical data is only available for prior months, starting with January 2014.
 func (c *Client) GetHistoricalDaily(req *HistoricalDailyRequest) ([]*Stats, error) {
 	var result []*Stats
@@ -345,6 +349,7 @@ func (c *Client) GetHistoricalDaily(req *HistoricalDailyRequest) ([]*Stats, erro
 	return result, err
 }
 
+// HistoricalDailyRequest holds optional data either for Date or Last
 type HistoricalDailyRequest struct {
 	// Option 1: Value needs to be in four-digit year, two-digit
 	// month format (YYYYMM) (i.e January 2017 would be written as 201701)
@@ -391,7 +396,7 @@ func (c *Client) GetNews(symbol string) ([]*News, error) {
 	return result, err
 }
 
-// GetStockQUotes returns a map of quotes for the given symbols.
+// GetStockQuotes returns a map of quotes for the given symbols.
 //
 // A maximumum of 100 symbols may be requested.
 func (c *Client) GetStockQuotes(symbols []string) (map[string]*StockQuote, error) {
@@ -423,14 +428,14 @@ func (c *Client) GetList(list string) ([]*StockQuote, error) {
 	return result, err
 }
 
-// GetCompany
+// GetCompany gets company information
 func (c *Client) GetCompany(symbol string) (*Company, error) {
 	var result *Company
 	err := c.getJSON("/stock/"+symbol+"/company", nil, &result)
 	return result, err
 }
 
-// GetDividends
+// GetDividends gets last 5 years of dividends
 func (c *Client) GetDividends(symbol string) ([]*Dividends, error) {
 	var result []*Dividends
 	err := c.getJSON("/stock/"+symbol+"/dividends/5y", nil, &result)


### PR DESCRIPTION
the client.go file now passes go lint checks.

some of the other files have exported fields that i was not sure meant so i could not accurately document. here are the other linting errors for other files.

```interface.go:3:7: exported const IEXTP1 should have comment or be unexported
interface.go:6:2: exported const StartMessages should have comment (or a comment on this block) or be unexported
interface.go:15:2: comment on exported const TradingHalted should be of the form "TradingHalted ..."
interface.go:17:2: comment on exported const TradingOrderAcceptancePeriod should be of the form "TradingOrderAcceptancePeriod ..."
interface.go:20:2: comment on exported const TradingPaused should be of the form "TradingPaused ..."
interface.go:28:2: comment on exported const HaltNewsPending should be of the form "HaltNewsPending ..."
interface.go:30:2: exported const IPOIssueNotYetTrading should have comment (or a comment on this block) or be unexported
interface.go:35:2: comment on exported const HaltNewsDisseminations should be of the form "HaltNewsDisseminations ..."
interface.go:44:2: exported const MarketOpen should have comment (or a comment on this block) or be unexported
interface.go:48:6: exported type TOPS should have comment or be unexported
interface.go:75:6: exported type Last should have comment or be unexported
interface.go:86:6: exported type HIST should have comment or be unexported
interface.go:101:6: exported type DEEP should have comment or be unexported
interface.go:120:6: exported type Quote should have comment or be unexported
interface.go:126:6: exported type SystemEvent should have comment or be unexported
interface.go:131:6: exported type TradingStatusMessage should have comment or be unexported
interface.go:137:6: exported type OpHaltStatus should have comment or be unexported
interface.go:142:6: exported type SSRStatus should have comment or be unexported
interface.go:148:6: exported type SecurityEventMessage should have comment or be unexported
interface.go:153:6: exported type Trade should have comment or be unexported
interface.go:165:6: exported type TradeBreak should have comment or be unexported
interface.go:177:6: exported type Book should have comment or be unexported
interface.go:182:6: exported type Market should have comment or be unexported
interface.go:203:6: exported type Symbol should have comment or be unexported
interface.go:214:6: exported type IntradayStats should have comment or be unexported
interface.go:242:6: exported type Stats should have comment or be unexported
interface.go:257:6: exported type Records should have comment or be unexported
interface.go:268:6: exported type Record should have comment or be unexported
interface.go:275:6: exported type HistoricalSummary should have comment or be unexported
interface.go:328:6: exported type KeyStats should have comment or be unexported
interface.go:383:6: exported type News should have comment or be unexported
interface.go:392:6: exported type StockQuote should have comment or be unexported
interface.go:431:6: exported type Company should have comment or be unexported
interface.go:451:6: exported type Dividends should have comment or be unexported
interface.go:481:6: exported type Chart should have comment or be unexported
pcap.go:15:2: a blank import should be only in a main or test package, or have a comment justifying it
pcap.go:25:6: exported type PacketDataSource should have comment or be unexported
pcap.go:30:1: comment on exported function NewPacketDataSource should be of the form "NewPacketDataSource ..."
pcap.go:43:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pcap.go:72:1: exported function NewPcapScanner should have comment or be unexported
pcap.go:79:1: comment on exported method PcapScanner.NextMessage should be of the form "NextMessage ..."
time.go:9:1: comment on exported type Time should be of the form "Time ..." (with optional leading article)
time.go:15:1: exported method Time.UnmarshalJSON should have comment or be unexported
time.go:32:1: exported method Time.MarshalJSON should have comment or be unexported```