### PR TITLE
Work around data type inconsistency in API

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -418,27 +418,24 @@ func TestGetIntradayStats(t *testing.T) {
 }
 
 func TestGetRecentStats(t *testing.T) {
-	// NOTE: this test is on hold until an upstream bug is handled
-	// ticket for reference: https://github.com/timpalpant/go-iex/issues/21
-	t.Skip("refer to ticket https://github.com/timpalpant/go-iex/issues/21")
 	// this file contains data from here:
 	// https://api.iextrading.com/1.0/stats/recent
-	// body, err := readTestData("stats_recent.json")
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
+	body, err := readTestData("stats_recent.json")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// httpc := mockHTTPClient{body: body, code: 200}
-	// c := NewClient(&httpc)
+	httpc := mockHTTPClient{body: body, code: 200}
+	c := NewClient(&httpc)
 
-	// result, err := c.GetRecentStats()
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
+	result, err := c.GetRecentStats()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// if result == nil {
-	// 	t.Fatalf("result was unexpectedly nil")
-	// }
+	if result == nil {
+		t.Fatalf("result was unexpectedly nil")
+	}
 }
 
 func TestGetNews(t *testing.T) {

--- a/interface_test.go
+++ b/interface_test.go
@@ -1,0 +1,90 @@
+package iex
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStatsUnmarshal_IntFalse(t *testing.T) {
+	intStats := []byte(`{
+		"date": "2017-05-09",
+		"volume": 152907569,
+		"routedVolume": 46943802,
+		"marketShare": 0.02246,
+		"isHalfday": 0,
+		"litVolume": 35426666
+	}`)
+
+	var stats *Stats
+	if err := json.Unmarshal(intStats, &stats); err != nil {
+		t.Fatal(err)
+	}
+
+	if stats.IsHalfDay {
+		t.Fatalf("did not unmarshal halfday correctly: got %v, expected %v",
+			stats.IsHalfDay, false)
+	}
+}
+
+func TestStatsUnmarshal_IntTrue(t *testing.T) {
+	intStats := []byte(`{
+		"date": "2017-05-09",
+		"volume": 152907569,
+		"routedVolume": 46943802,
+		"marketShare": 0.02246,
+		"isHalfday": 1,
+		"litVolume": 35426666
+	}`)
+
+	var stats *Stats
+	if err := json.Unmarshal(intStats, &stats); err != nil {
+		t.Fatal(err)
+	}
+
+	if !stats.IsHalfDay {
+		t.Fatalf("did not unmarshal halfday correctly: got %v, expected %v",
+			stats.IsHalfDay, true)
+	}
+}
+
+func TestStatsUnmarshal_BoolFalse(t *testing.T) {
+	boolStats := []byte(`{
+		"date": "2017-01-11",
+		"volume": 128048723,
+		"routedVolume": 38314207,
+		"marketShare": 0.01769,
+		"isHalfday": false,
+		"litVolume": 30520534
+	}`)
+
+	var stats *Stats
+	if err := json.Unmarshal(boolStats, &stats); err != nil {
+		t.Fatal(err)
+	}
+
+	if stats.IsHalfDay {
+		t.Fatalf("did not unmarshal halfday correctly: got %v, expected %v",
+			stats.IsHalfDay, false)
+	}
+}
+
+func TestStatsUnmarshal_BoolTrue(t *testing.T) {
+	boolStats := []byte(`{
+		"date": "2017-01-11",
+		"volume": 128048723,
+		"routedVolume": 38314207,
+		"marketShare": 0.01769,
+		"isHalfday": true,
+		"litVolume": 30520534
+	}`)
+
+	var stats *Stats
+	if err := json.Unmarshal(boolStats, &stats); err != nil {
+		t.Fatal(err)
+	}
+
+	if !stats.IsHalfDay {
+		t.Fatalf("did not unmarshal halfday correctly: got %v, expected %v",
+			stats.IsHalfDay, true)
+	}
+}


### PR DESCRIPTION
Implements a custom unmarshaller for the Stats type that can handle a bool encoded as either a JSON int or bool type (fixes #21). This allows the type to be used for both intraday and historical daily requests.