### PR TITLE
Modified Type of StockQuote.Week52Low

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -464,7 +464,7 @@ type StockQuote struct {
 	MarketCap        int64   // is calculated in real time using calculationPrice.
 	PeRatio          float64 // is calculated in real time using calculationPrice.
 	Week52High       float64 // refers to the adjusted 52 week high.
-	Week52Low        float64 // refers to the adjusted 52 week low.
+	Week52Low        json.RawMessage // refers to the adjusted 52 week low.
 	YtdChange        float64 // refers to the price change percentage from start of year to previous close.
 }
 


### PR DESCRIPTION
Modified type of StockQuote.Week52Low to address an issue that occurs when the week 52 low is a string.

This issue occurs when the JSON conversion fails due to the field type being float64 but the data being converted being of type string. By changing the field type to json.RawMessage, this resolves the issue in an unfortunately hacky way.